### PR TITLE
a better require

### DIFF
--- a/code/main.R
+++ b/code/main.R
@@ -17,7 +17,13 @@ start.proc.time <- proc.time();
 setwd( output.directory );
 
 ##################################################
-require(reticulate);
+if(!require(reticulate)){
+    install.packages("reticulate")
+    library(reticulate)
+} 
+else {
+    library(reticulate)
+}
 
 # source supporting R code
 code.files <- c(


### PR DESCRIPTION
A slightly optimized use of `require`. If the library is missing, install it and load it, otherwise just load it. Otherwise, main.R halts and installation fails.